### PR TITLE
Add email as a way to contact ORY about jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 We build stuff for an emerging cloud infrastructure. It’s security, zero trust, hardcore bullet proof engineering.
 It’s Golang, K8S, React, Hashicorp etc. - no more buzzwords! Just [open an issue](https://github.com/ory/jobs/issues/new)
-and go ahead, make our day. We believe that great engineering deserves to be paid accordingly.
+and go ahead, make our day :) - or drop us a short introductory email to jared@ory.sh. We believe that great engineering deserves to be paid accordingly.
 
 Our open positions:
 


### PR DESCRIPTION
Add email as a way to contact about jobs at ORY in case there are issues for people nervous about being to public about their job search.